### PR TITLE
Implement basic home page routing and error handler

### DIFF
--- a/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/controller/GlobalExceptionHandler.java
+++ b/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/controller/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package ru.kpfu.itis.semestrovka_2sem.controller;
+
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.http.HttpStatus;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public String handleIllegalArgument(IllegalArgumentException ex, Model model) {
+        model.addAttribute("errorMessage", ex.getMessage());
+        return "error"; // templates/error.html
+    }
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    public String handleGeneral(Exception ex, Model model) {
+        model.addAttribute("errorMessage", "Внутренняя ошибка приложения");
+        return "error";
+    }
+}

--- a/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/controller/MainController.java
+++ b/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/controller/MainController.java
@@ -1,0 +1,13 @@
+package ru.kpfu.itis.semestrovka_2sem.controller;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class MainController {
+
+    @GetMapping("/")
+    public String index() {
+        return "index";
+    }
+}

--- a/semestrovka_2sem/src/main/resources/templates/error.html
+++ b/semestrovka_2sem/src/main/resources/templates/error.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" lang="ru">
+<head th:replace="~{fragments/layout :: baseHead('Ошибка')}"></head>
+<body>
+<div th:replace="~{fragments/layout :: baseHeader}"></div>
+<div th:replace="~{fragments/layout :: baseContent}">
+  <h2>Произошла ошибка</h2>
+  <p th:text="${errorMessage}">Неизвестная ошибка</p>
+  <p><a th:href="@{/}">На главную</a></p>
+</div>
+<div th:replace="~{fragments/layout :: baseFooter}"></div>
+<div th:replace="~{fragments/layout :: pageScripts}"></div>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- show home page via new `MainController`
- handle errors globally with `GlobalExceptionHandler`
- display user-friendly messages on new `error.html` template

## Testing
- `./mvnw -q test` *(fails: cannot download Maven)*
- `./mvnw -q -DskipTests package` *(fails: cannot download Maven)*

------
https://chatgpt.com/codex/tasks/task_e_684441fbd508832aa14c73c37e27eb8a