### PR TITLE
fix tutor subject creation bug

### DIFF
--- a/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorRequestServiceImpl.java
+++ b/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorRequestServiceImpl.java
@@ -51,8 +51,9 @@ public class TutorRequestServiceImpl implements TutorRequestService {
                 throw new IllegalArgumentException("Название предмета не задано");
             }
             subjName = subjName.trim();
-            subject = subjectRepository.findByNameIgnoreCase(subjName)
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(subjName).build()));
+            final String finalSubjName = subjName;
+            subject = subjectRepository.findByNameIgnoreCase(finalSubjName)
+                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(finalSubjName).build()));
         }
 
         // 3) Проверка price > 0
@@ -131,9 +132,10 @@ public class TutorRequestServiceImpl implements TutorRequestService {
                             "Subject с ID " + updateDto.getSubjectId() + " не найден"));
         } else if (updateDto.getSubjectName() != null && !updateDto.getSubjectName().isBlank()) {
             String subjName = updateDto.getSubjectName().trim();
-            newSubject = subjectRepository.findByNameIgnoreCase(subjName)
+            final String finalSubjName = subjName;
+            newSubject = subjectRepository.findByNameIgnoreCase(finalSubjName)
 
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(subjName).build()));
+                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(finalSubjName).build()));
         }
         if (newSubject != null && !existing.getSubject().getId().equals(newSubject.getId())) {
             existing.setSubject(newSubject);

--- a/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorServiceImpl.java
+++ b/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorServiceImpl.java
@@ -51,9 +51,9 @@ public class TutorServiceImpl implements TutorService {
 
         if (dto.getNewSubjectName() != null && !dto.getNewSubjectName().isBlank()) {
             String name = dto.getNewSubjectName().trim();
-            Subject extra = subjectRepository.findByNameIgnoreCase(name)
-
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(name).build()));
+            final String finalName = name;
+            Subject extra = subjectRepository.findByNameIgnoreCase(finalName)
+                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(finalName).build()));
             subjects.add(extra);
         }
 
@@ -105,8 +105,9 @@ public class TutorServiceImpl implements TutorService {
 
         if (dto.getNewSubjectName() != null && !dto.getNewSubjectName().isBlank()) {
             String name = dto.getNewSubjectName().trim();
-            Subject extra = subjectRepository.findByNameIgnoreCase(name)
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(name).build()));
+            final String finalName = name;
+            Subject extra = subjectRepository.findByNameIgnoreCase(finalName)
+                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(finalName).build()));
             newSubjects.add(extra);
         }
 


### PR DESCRIPTION
## Summary
- ensure subject name variable remains effectively final when creating or updating tutors

## Testing
- `./mvnw -q -DskipTests package` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7b29fb8832a97a9e2075b091670