### PR TITLE
Исправлена ошибка создания заявки

### DIFF
--- a/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorRequestServiceImpl.java
+++ b/semestrovka_2sem/src/main/java/ru/kpfu/itis/semestrovka_2sem/service/impl/TutorRequestServiceImpl.java
@@ -51,8 +51,10 @@ public class TutorRequestServiceImpl implements TutorRequestService {
                 throw new IllegalArgumentException("Название предмета не задано");
             }
             subjName = subjName.trim();
-            subject = subjectRepository.findByNameIgnoreCase(subjName)
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(subjName).build()));
+            final String finalSubjName = subjName;
+            subject = subjectRepository.findByNameIgnoreCase(finalSubjName)
+                    .orElseGet(() -> subjectRepository.saveAndFlush(
+                            Subject.builder().name(finalSubjName).build()));
         }
 
         // 3) Проверка price > 0
@@ -77,7 +79,7 @@ public class TutorRequestServiceImpl implements TutorRequestService {
                 .createdAt(LocalDateTime.now())
                 .build();
 
-        return tutorRequestRepository.save(entity);
+        return tutorRequestRepository.saveAndFlush(entity);
     }
 
     @Override
@@ -131,9 +133,11 @@ public class TutorRequestServiceImpl implements TutorRequestService {
                             "Subject с ID " + updateDto.getSubjectId() + " не найден"));
         } else if (updateDto.getSubjectName() != null && !updateDto.getSubjectName().isBlank()) {
             String subjName = updateDto.getSubjectName().trim();
-            newSubject = subjectRepository.findByNameIgnoreCase(subjName)
+            final String finalSubjName = subjName;
+            newSubject = subjectRepository.findByNameIgnoreCase(finalSubjName)
 
-                    .orElseGet(() -> subjectRepository.save(Subject.builder().name(subjName).build()));
+                    .orElseGet(() -> subjectRepository.saveAndFlush(
+                            Subject.builder().name(finalSubjName).build()));
         }
         if (newSubject != null && !existing.getSubject().getId().equals(newSubject.getId())) {
             existing.setSubject(newSubject);
@@ -156,7 +160,7 @@ public class TutorRequestServiceImpl implements TutorRequestService {
         // Обновляем описание
         existing.setDescription(updateDto.getDescription());
 
-        return tutorRequestRepository.save(existing);
+        return tutorRequestRepository.saveAndFlush(existing);
     }
 
     @Override


### PR DESCRIPTION
## Notes
- Добавлен вызов `saveAndFlush` при сохранении предмета и самой заявки. Это позволяет сразу получить ошибки БД и корректно обработать их в контроллере.

## Testing
- `./mvnw -q -DskipTests package` *(ошибка загрузки зависимостей из-за отсутствия доступа к интернету)*

------
https://chatgpt.com/codex/tasks/task_e_6845b7b29fb8832a97a9e2075b091670